### PR TITLE
starting lick detector value reads correctly

### DIFF
--- a/firmware/inc/lick_detector.h
+++ b/firmware/inc/lick_detector.h
@@ -56,27 +56,9 @@ public:
 
     LickDetector(uint16_t* adc_vals, size_t samples_per_period,
                  uint ttl_pin, uint led_pin,
-                 uint32_t on_threshold_percent = DEFAULT_ON_THRESHOLD_PERCENT,
-                 uint32_t off_threshold_percent = DEFAULT_OFF_THRESHOLD_PERCENT);
+                 uint8_t on_threshold_percent = DEFAULT_ON_THRESHOLD_PERCENT,
+                 uint8_t off_threshold_percent = DEFAULT_OFF_THRESHOLD_PERCENT);
     ~LickDetector();
-
-/**
- * \brief set the percent deviation from nominal that would trigger a detected
- *  lick.
- * \note should be less than the "off threshold."
- * \note value is an integer between 0 and 100. FIXME: enable more granularity.
- */
-    void set_on_threshold_percent(uint32_t percent)
-    {on_threshold_percent_ = percent;}
-
-/**
- * \brief set the percent deviation from nominal that would clear a detected
- *  lick.
- * \note should be greater than the "on threshold."
- * \note value is an integer between 0 and 100. FIXME: enable more granularity.
- */
-    void set_off_threshold_percent(uint32_t percent)
-    {off_threshold_percent_ = percent;}
 
 /**
  * \brief reset finite state machine for lick detection.
@@ -97,6 +79,10 @@ public:
     inline void clear_lick_detection_stop_flag()
         {lick_stop_detected_ = false;}
 
+// Public Data members.
+    uint8_t on_threshold_percent_; /// public access for speed.
+    uint8_t off_threshold_percent_; /// public access for speed.
+
 private:
 /**
  * \brief compute the raw amplitude from one period of waveform samples.
@@ -115,9 +101,6 @@ private:
  */
     inline void update_baseline_moving_avg();
 
-
-
-// Data members.
 private:
     uint ttl_pin_;
     uint led_pin_;
@@ -147,8 +130,6 @@ private:
     bool hysteresis_elapsed_;
 
 
-    uint32_t on_threshold_percent_;
-    uint32_t off_threshold_percent_;
     uint32_t detection_start_time_ms_;
     uint32_t detection_stop_time_ms_;
 };

--- a/firmware/inc/lick_queue.h
+++ b/firmware/inc/lick_queue.h
@@ -12,8 +12,9 @@ struct lick_event_t
 extern queue_t lick_event_queue;
 
 // Additional queues for adjusting lick detector thresholds from Harp registers.
-extern queue_t on_threshold_queue;
-extern queue_t off_threshold_queue;
-
+extern queue_t set_on_threshold_queue;
+extern queue_t set_off_threshold_queue;
+extern queue_t get_on_threshold_queue;
+extern queue_t get_off_threshold_queue;
 
 #endif // LICK_QUEUE_H

--- a/firmware/src/lick_detector.cpp
+++ b/firmware/src/lick_detector.cpp
@@ -1,8 +1,8 @@
 #include <lick_detector.h>
 
 LickDetector::LickDetector(uint16_t* adc_vals, size_t samples_per_period,
-                           uint ttl_pin, uint led_pin, uint32_t on_threshold_percent,
-                           uint32_t off_threshold_percent)
+                           uint ttl_pin, uint led_pin, uint8_t on_threshold_percent,
+                           uint8_t off_threshold_percent)
 :adc_vals_{adc_vals},
  samples_per_period_{samples_per_period},
  state_{RESET},
@@ -124,9 +124,9 @@ void LickDetector::update()
     }
     // Recompute trigger thresholds based on current baseline measurement and
     // current threshold percentage settings.
-    uint32_t on_threshold = __mul_instruction(on_threshold_percent_,
+    uint32_t on_threshold = __mul_instruction((uint32_t)on_threshold_percent_,
                                               upscaled_baseline_avg_) / 100;
-    uint32_t off_threshold = __mul_instruction(off_threshold_percent_,
+    uint32_t off_threshold = __mul_instruction((uint32_t)off_threshold_percent_,
                                                upscaled_baseline_avg_) / 100;
     if (state_ & ~(RESET | WARMUP))
     {


### PR DESCRIPTION
Since the threshold data is on core1, we need a way to send the thresholds back from core1 to core1. 

This PR adds another 2 queues to send the setpoint value from core1 back to core0 such that it can be applied to the relevant Harp register.

Addresses: https://github.com/AllenNeuralDynamics/harp.device.lickety-split/issues/22